### PR TITLE
Fix exception to be correctly serialized into json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # python3-base-image
 Python 3 language support for Dispatch
 
-Latest image [on Docker Hub](https://hub.docker.com/r/dispatchframework/python3-base/): `dispatchframework/python3-base:0.0.3`
+Latest image [on Docker Hub](https://hub.docker.com/r/dispatchframework/python3-base/): `dispatchframework/python3-base:0.0.4`
 
 ## Usage
 
@@ -11,7 +11,7 @@ You need a recent version of Dispatch [installed in your Kubernetes cluster, Dis
 
 To add the base-image to Dispatch:
 ```bash
-$ dispatch create base-image python3-base dispatchframework/python3-base:0.0.3
+$ dispatch create base-image python3-base dispatchframework/python3-base:0.0.4
 ```
 
 Make sure the base-image status is `READY` (it normally goes from `INITIALIZED` to `READY`):

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@ set -e -x
 
 cd $(dirname $0)
 
-docker build -t dispatchframework/python3-base:0.0.3 .
+docker build -t dispatchframework/python3-base:0.0.4 .

--- a/function-server/main.py
+++ b/function-server/main.py
@@ -1,4 +1,5 @@
 import json
+import traceback
 import signal
 import sys
 import io
@@ -20,13 +21,17 @@ def read_logs(text_io):
     return [line.rstrip('\n') for line in text_io]
 
 
-def exec_function(req, res):
+def get_msg(req):
     msg = None
     if req.content_length:
         msg = json.load(req.stream)
+    return msg
 
+
+def process_msg(msg, handle):
     r = None
     err = None
+    stacktrace = None
 
     stderr = io.StringIO()
     old_stderr = sys.stderr
@@ -37,9 +42,11 @@ def exec_function(req, res):
     try:
         sys.stderr = stderr
         sys.stdout = stdout
-        r = handler.handle(msg['context'], msg['payload'])
+        r = handle(msg['context'], msg['payload'])
     except Exception as e:
         err = e
+        stacktrace = traceback.format_exc().rstrip()
+        print(stacktrace, file=sys.stderr)
     finally:
         sys.stderr = old_stderr
         stderr.flush()
@@ -47,18 +54,32 @@ def exec_function(req, res):
         sys.stdout = old_stdout
         stdout.flush()
 
-    res.body = json.dumps({'context': {'error': err, 'logs': {'stdout': read_logs(stdout), 'stderr': read_logs(stderr)}}, 'payload': r}, ensure_ascii=False)
+        # Exception is not json-serializable, so have to serialize ourselves
+        if err is not None:
+            err = {'message': str(err), 'stacktrace': stacktrace, 'type': err.__class__.__name__}
+
+    return json.dumps({'context': {'error': err, 'logs': {'stdout': read_logs(stdout), 'stderr': read_logs(stderr)}}, 'payload': r}, ensure_ascii=False)
+
+
+def exec_function(req, res):
+    msg = get_msg(req)
+    res.body = process_msg(msg, handler.handle)
 
 
 def signal_handler(signum, frame):
     sys.exit(0)
 
 
-signal.signal(signal.SIGINT, signal_handler)
-signal.signal(signal.SIGTERM, signal_handler)
+def main():
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
 
-app = falcon.API()
-app.add_route('/healthz', Health())
-app.add_sink(exec_function, '/')
+    app = falcon.API()
+    app.add_route('/healthz', Health())
+    app.add_sink(exec_function, '/')
 
-waitress.serve(app, threads=1)
+    waitress.serve(app, threads=1)
+
+
+if __name__ == "__main__":
+    main()

--- a/function-server/test_main.py
+++ b/function-server/test_main.py
@@ -1,0 +1,115 @@
+import io
+import json
+import sys
+import unittest
+
+import main
+
+
+def hello(ctx, payload):
+    name = "Noone"
+    place = "Nowhere"
+    if payload:
+        name = payload.get("name", name)
+        place = payload.get("place", place)
+    return "Hello, %s from %s" % (name, place)
+
+
+def fail(ctx, payload):
+    raise ZeroDivisionError("oh no!")
+
+
+def logger(ctx, payload):
+    print("stdout")
+    print("stderr", file=sys.stderr)
+    print("stdout2")
+    print("stderr2", file=sys.stderr)
+
+
+class Request():
+    """
+    Mock of a part of the falcon.Request class
+    """
+    def __init__(self, content_length=0, stream=None):
+        self.content_length = content_length
+        self.stream = stream
+
+
+class TestMainMethods(unittest.TestCase):
+
+
+    def test_read_logs_valid(self):
+        text_io = io.StringIO()
+        print("line 1", file=text_io)
+        print("line 2", file=text_io)
+        logs = main.read_logs(text_io)
+
+        self.assertEqual(["line 1", "line 2"], logs)
+
+
+    def test_read_logs_empty(self):
+        text_io = io.StringIO()
+        logs = main.read_logs(text_io)
+
+        self.assertEqual(0, len(logs))
+
+
+    def test_get_msg_valid(self):
+        m = "{\"context\": null, \"payload\": {\"name\": \"Jon\", \"place\": \"Winterfell\"}}"
+        req_stream = io.StringIO(m)
+        req = Request(content_length=len(m), stream=req_stream)
+        
+        msg = main.get_msg(req)
+
+        self.assertIn('context', msg)
+        self.assertIsNone(msg['context'])
+        self.assertIn('payload', msg)
+        self.assertEqual({"name": "Jon", "place": "Winterfell"}, msg['payload'])
+
+
+    def test_get_msg_empty(self):
+        msg = main.get_msg(Request())
+
+        self.assertIsNone(msg)
+
+
+    def test_process_msg_valid(self):
+        msg = {'context': None, 'payload': {"name": "Jon", "place": "Winterfell"}}
+        body = main.process_msg(msg, hello)
+        
+        r = json.loads(body)
+
+        self.assertEqual("Hello, Jon from Winterfell", r['payload']);
+        self.assertEqual(0, len(r['context']['logs']['stdout']));
+        self.assertEqual(0, len(r['context']['logs']['stderr']));
+        self.assertIsNone(r['context']['error'])
+
+
+    def test_process_msg_exception(self):
+        msg = {'context': None, 'payload': None}
+        body = main.process_msg(msg, fail)
+        
+        r = json.loads(body)
+        err = r['context']['error']
+        stderr = main.read_logs(io.StringIO(err['stacktrace']))
+
+        self.assertIsNone(r['payload'])
+        self.assertEqual("ZeroDivisionError", err['type'])
+        self.assertEqual("oh no!", err['message'])
+        self.assertEqual(stderr, r['context']['logs']['stderr'])
+        self.assertEqual(0, len(r['context']['logs']['stdout']))
+
+
+    def test_process_msg_logs(self):
+        msg = {'context': None, 'payload': None}
+        body = main.process_msg(msg, logger)
+        r = json.loads(body)
+
+        self.assertIsNone(r['payload'])
+        self.assertIsNone(r['context']['error'])
+        self.assertEqual(["stderr", "stderr2"], r['context']['logs']['stderr'])
+        self.assertEqual(["stdout", "stdout2"], r['context']['logs']['stdout'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #4

Python exceptions are not json-serializable so have extract out information from exception to be serialized